### PR TITLE
Use TreeSet instead of LinkedList

### DIFF
--- a/src/main/kotlin/com/github/jonpeterson/kotlin/ranges/RangeSets.kt
+++ b/src/main/kotlin/com/github/jonpeterson/kotlin/ranges/RangeSets.kt
@@ -41,6 +41,8 @@ class IntRangeSet : RangeSet<Int> {
     override fun decrementValue(value: Int): Int = value - 1
 
     override fun clone(): RangeSet<Int> = IntRangeSet(this)
+
+    protected override fun empty(): IntRangeSet = IntRangeSet()
 }
 
 class LongRangeSet : RangeSet<Long> {
@@ -60,6 +62,8 @@ class LongRangeSet : RangeSet<Long> {
     override fun decrementValue(value: Long): Long = value - 1
 
     override fun clone(): RangeSet<Long> = LongRangeSet(this)
+
+    protected override fun empty(): LongRangeSet = LongRangeSet()
 }
 
 class CharRangeSet : RangeSet<Char> {
@@ -79,4 +83,6 @@ class CharRangeSet : RangeSet<Char> {
     override fun decrementValue(value: Char): Char = value - 1
 
     override fun clone(): RangeSet<Char> = CharRangeSet(this)
+
+    protected override fun empty(): CharRangeSet = CharRangeSet()
 }


### PR DESCRIPTION
Hello. I made a version of kotlin-range-sets that uses TreeSet instead of LinkedList. This should be much more efficient (I haven't actually benchmarked it, however), and also shrinks the code somewhat.